### PR TITLE
Revert "Update spring boot version to 3.1.5"

### DIFF
--- a/complete/say-hello/build.gradle
+++ b/complete/say-hello/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '3.1.5'
+	id 'org.springframework.boot' version '3.0.0'
 	id 'io.spring.dependency-management' version '1.1.0'
 	id 'java'
 }

--- a/complete/say-hello/pom.xml
+++ b/complete/say-hello/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.5</version>
+		<version>3.0.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/complete/user/build.gradle
+++ b/complete/user/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '3.1.5'
+	id 'org.springframework.boot' version '3.0.0'
 	id 'io.spring.dependency-management' version '1.1.0'
 	id 'java'
 }

--- a/complete/user/pom.xml
+++ b/complete/user/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.5</version>
+    <version>3.0.0</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 

--- a/initial/say-hello/build.gradle
+++ b/initial/say-hello/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '3.1.5'
+	id 'org.springframework.boot' version '3.0.0'
 	id 'io.spring.dependency-management' version '1.1.0'
 	id 'java'
 }

--- a/initial/say-hello/pom.xml
+++ b/initial/say-hello/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.5</version>
+		<version>3.0.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/initial/user/build.gradle
+++ b/initial/user/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '3.1.5'
+	id 'org.springframework.boot' version '3.0.0'
 	id 'io.spring.dependency-management' version '1.1.0'
 	id 'java'
 }

--- a/initial/user/pom.xml
+++ b/initial/user/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.5</version>
+		<version>3.0.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>


### PR DESCRIPTION
This reverts commit 53b59ef2b3f4b13eecab3d5c5956ef2f2c815d17. It turns out that Spring Boot and Spring Cloud have not yet synchronized, as indicated by this error message: Spring Cloud/ Spring Boot version compatibility checks have failed: [[VerificationResult@2c719bd4 description = 'Spring Boot [3.1.5] is not compatible with this Spring Cloud release train', action = 'Change Spring Boot version to one of the following versions [3.0.x] .

So we'll leave it at 3.0.0 for now.